### PR TITLE
Quick swing at PIN expansion

### DIFF
--- a/backup/crypto.go
+++ b/backup/crypto.go
@@ -4,11 +4,17 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha256"	
+	"crypto/sha256"
 	"io"
 	"io/ioutil"
+	"math"
 	"os"
+
+	"golang.org/x/crypto/scrypt"
+	"golang.org/x/xerrors"
 )
+
+const SaltFile = "salt.bin"
 
 func encryptFile(source, dest string, key []byte) error {
 	fileContent, err := ioutil.ReadFile(source)
@@ -35,6 +41,30 @@ func encryptFile(source, dest string, key []byte) error {
 
 	if err = ioutil.WriteFile(dest, encryptedContent, os.ModePerm); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func decryptFiles(pin string, files []string) error {
+	decKey := deriveEncryptionKey(pin)
+
+	for i, p := range files {
+		if p == SaltFile {
+			continue
+		}
+
+		destPath := p + ".decrypted"
+		err := decryptFile(p, destPath, decKey)
+		if err != nil {
+			return xerrors.New("Failed to restore backup due to incorrect PIN")
+		}
+		if err = os.Remove(files[i]); err != nil {
+			return err
+		}
+		if err = os.Rename(destPath, files[i]); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -71,10 +101,63 @@ func decryptFile(source, dest string, key []byte) error {
 	return nil
 }
 
-func generateEncryptionKey(pin string) []byte {
+func generateSalt() ([]byte, error) {
+	const saltLength = 32
+
+	var salt = make([]byte, saltLength)
+	n, err := rand.Read(salt)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != saltLength {
+		return nil, xerrors.New("unexpected salt length")
+	}
+
+	return salt, nil
+}
+
+func initSalt() error {
+	salt, err := generateSalt()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(SaltFile, salt, os.ModePerm)
+}
+
+func deriveScryptKey(pin string, salt []byte) []byte {
+	// NOTE: N, r, and p params used as per doc recommendation:
+	//      https://godoc.org/golang.org/x/crypto/scrypt
+
+	// N has to be a power of 2
+	var N = int(math.Pow(2, 15))
+
+	sum, err := scrypt.Key([]byte(pin), []byte(salt), N, 8, 1, 32)
+	if err != nil {
+		panic("Scrypt constant params are configured incorrectly.  Can.  Not.  Continue.")
+	}
+	return sum[:]
+}
+
+func deriveSha256Key(pin string) []byte {
+	sum := sha256.Sum256([]byte(pin))
+	return sum[:]
+}
+
+func deriveEncryptionKey(pin string) []byte {
 	if pin == "" {
 		return nil
 	}
-	sum := sha256.Sum256([]byte(pin))
-	return sum[:]
+
+	salt, err := ioutil.ReadFile(SaltFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return deriveSha256Key(pin)
+		}
+
+		// TODO: on unknown error while reading salt ??? 🤔
+	}
+
+	return deriveScryptKey(pin, salt)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,11 @@ require (
 	github.com/urfave/cli v1.18.0
 	go.etcd.io/bbolt v1.3.2
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/api v0.7.0
 	google.golang.org/grpc v1.22.0
 	gopkg.in/macaroon.v2 v2.0.0


### PR DESCRIPTION
Scrypt is conveniently quite a lot slower than SHA256, and AFAIK was designed with that in mind too.

```
go test -run=NONE -bench BenchmarkDerive github.com/breez/breez/backup
go: finding github.com/golang/net latest
goos: darwin
goarch: amd64
pkg: github.com/breez/breez/backup
BenchmarkDeriveScryptKey-4   	      10	 102314470 ns/op
BenchmarkDeriveSha256Key-4   	 2000000	       683 ns/op
PASS
ok  	github.com/breez/breez/backup	3.812s
```

While not perfect, this approach makes brute-forcing annoyingly more resource, and time intensive.

The only changes needed are:

* Securely random `salt` must be generated upon wallet setup
* `salt` can be synced plaintext to gdrive
* before decryption, the salt file needs to be read
* migration path for users with prior backups

Note: I only run this code through tests, and benchmarks, as I haven't gotten the whole project to run.